### PR TITLE
Enable support for rolling window maps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,10 +97,9 @@ endif()
 ##     and list every .cfg file to be processed
 
 ## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
+generate_dynamic_reconfigure_options(
+  cfg/CostmapProhibitionLayer.cfg
+)
 
 ###################################
 ## catkin specific configuration ##
@@ -127,6 +126,8 @@ include_directories(${catkin_INCLUDE_DIRS} include)
 
 add_library(costmap_prohibition_layer src/costmap_prohibition_layer.cpp)
 
+# Dynamic reconfigure: make sure configure headers are built before any node using them
+add_dependencies(costmap_prohibition_layer ${PROJECT_NAME}_gencfg)
 
 ############
 ## Install ##
@@ -159,6 +160,12 @@ install(DIRECTORY include/${PROJECT_NAME}/
 install(FILES
   costmap_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(DIRECTORY
+  cfg
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  PATTERN ".svn" EXCLUDE
 )
 
 #############

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,10 @@ generate_dynamic_reconfigure_options(
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES costmap_prohibition_layer
+  CATKIN_DEPENDS costmap_2d dynamic_reconfigure
+  DEPENDS
 )
 
 ###########
@@ -125,6 +129,7 @@ include_directories(${catkin_INCLUDE_DIRS} include)
 ## Declare a C++ library
 
 add_library(costmap_prohibition_layer src/costmap_prohibition_layer.cpp)
+target_link_libraries(costmap_prohibition_layer ${catkin_LIBRARIES})
 
 # Dynamic reconfigure: make sure configure headers are built before any node using them
 add_dependencies(costmap_prohibition_layer ${PROJECT_NAME}_gencfg)

--- a/cfg/CostmapProhibitionLayer.cfg
+++ b/cfg/CostmapProhibitionLayer.cfg
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+# For integers and doubles:
+#       Name                    Type      Reconfiguration level
+#       Description
+#       Default  Min  Max
+
+
+gen.add("enabled", bool_t, 0, "Whether to apply this plugin or not", True)
+gen.add("fill_polygons", bool_t, 0, "Whether to fill polygon cells or not", True)
+
+exit(gen.generate("costmap_prohibition_layer_namespace", "costmap_prohibition_layer_namespace", "CostmapProhibitionLayer"))

--- a/include/costmap_prohibition_layer/costmap_prohibition_layer.h
+++ b/include/costmap_prohibition_layer/costmap_prohibition_layer.h
@@ -47,7 +47,7 @@
 #include <ros/ros.h>
 #include <costmap_2d/layer.h>
 #include <costmap_2d/layered_costmap.h>
-#include <costmap_2d/GenericPluginConfig.h>
+#include <costmap_prohibition_layer/CostmapProhibitionLayerConfig.h>
 #include <dynamic_reconfigure/server.h>
 
 #include <unordered_map>
@@ -65,11 +65,16 @@ struct PointInt
 class CostmapProhibitionLayer : public costmap_2d::Layer
 {
 public:
+    
   /**
-   * unused constructor
+   * default constructor
    */
   CostmapProhibitionLayer();
 
+  /**
+   * destructor
+   */
+  virtual ~CostmapProhibitionLayer();
   /**
    * function which get called at initializing the costmap
    * define the reconfige callback, get the reoslution
@@ -98,7 +103,7 @@ private:
   /**
    * overlayed reconfigure callback function
    */
-  void reconfigureCB(costmap_2d::GenericPluginConfig& config, uint32_t level);
+  void reconfigureCB(CostmapProhibitionLayerConfig& config, uint32_t level);
 
   /**
    * Compute bounds in world coordinates for the current set of points and polygons.
@@ -188,7 +193,7 @@ private:
   */
   bool getPoint(XmlRpc::XmlRpcValue& val, geometry_msgs::Point& point);
 
-  dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>* dsrv_;          //!< dynamic_reconfigure server for the costmap
+  dynamic_reconfigure::Server<CostmapProhibitionLayerConfig>* _dsrv;          //!< dynamic_reconfigure server for the costmap
   std::mutex _parse_mutex;                                                      //!< mutex for the YAML Import
   double _costmap_resolution;                                                   //!< resolution of the overlayed costmap to create the thinnest line out of two points
   bool _fill_polygons;                                                          //!< if true, all cells that are located in the interior of polygons are marked as obstacle as well

--- a/include/costmap_prohibition_layer/costmap_prohibition_layer.h
+++ b/include/costmap_prohibition_layer/costmap_prohibition_layer.h
@@ -193,8 +193,8 @@ private:
   */
   bool getPoint(XmlRpc::XmlRpcValue& val, geometry_msgs::Point& point);
 
-  dynamic_reconfigure::Server<CostmapProhibitionLayerConfig>* _dsrv;          //!< dynamic_reconfigure server for the costmap
-  std::mutex _parse_mutex;                                                      //!< mutex for the YAML Import
+  dynamic_reconfigure::Server<CostmapProhibitionLayerConfig>* _dsrv;            //!< dynamic_reconfigure server for the costmap
+  std::mutex _data_mutex;                                                       //!< mutex for the accessing _prohibition_points and _prohibition_polygons
   double _costmap_resolution;                                                   //!< resolution of the overlayed costmap to create the thinnest line out of two points
   bool _fill_polygons;                                                          //!< if true, all cells that are located in the interior of polygons are marked as obstacle as well
   std::vector<geometry_msgs::Point> _prohibition_points;                        //!< vector to save the lonely points in source coordinates

--- a/include/costmap_prohibition_layer/costmap_prohibition_layer.h
+++ b/include/costmap_prohibition_layer/costmap_prohibition_layer.h
@@ -70,6 +70,13 @@ public:
   virtual void onInitialize();
 
   /**
+ * This is called by the LayeredCostmap to poll this plugin
+ * as to how much of the costmap it needs to update.
+ * Each layer can increase the size of this bounds. 
+ */
+  virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double *min_x, double *min_y, double *max_x, double *max_y);
+  
+    /**
  * function which get called at every cost updating procdure
  * of the overlayed costmap. The before readed costs will get
  * filled
@@ -82,6 +89,12 @@ private:
     */
   void reconfigureCB(costmap_2d::GenericPluginConfig& config, uint32_t level);
 
+    
+  void computeMapBounds();
+  
+  bool transformProhibitionAreas();
+  void transformPoint(const tf::StampedTransform& transform, const geometry_msgs::Point& pt_in, geometry_msgs::Point& pt_out);
+  
   /**
    * read the prohibition areas in YAML-Format from the
    * ROS parameter server in the namespace of this
@@ -109,12 +122,15 @@ private:
   */
   bool getPoint(XmlRpc::XmlRpcValue& val, geometry_msgs::Point& point);
 
-  dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>* dsrv_;   // dynamic_reconfigure server for the costmap
-  std::mutex _parse_mutex;                                               // mutex for the YAML Import
-  double _costmap_resolution;                                            // resolution of the overlayed costmap to create the thinnest line out of two points
-  std::vector<geometry_msgs::Point> _prohibition_points;                 // vector to save the lonely points
-  std::vector<std::vector<geometry_msgs::Point>> _prohibition_polygons;  // vecotr to save the polygons (including
-                                                                         // lines)
+  dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>* dsrv_;          //!< dynamic_reconfigure server for the costmap
+  std::mutex _parse_mutex;                                                      //!< mutex for the YAML Import
+  double _costmap_resolution;                                                   //!< resolution of the overlayed costmap to create the thinnest line out of two points
+  std::string _source_frame;                                                    //!< coordinate frame in which the prohibition points and polygons are defined
+  std::vector<geometry_msgs::Point> _prohibition_points;                        //!< vector to save the lonely points in source coordinates
+  std::vector<geometry_msgs::Point> _prohibition_points_global;                 //!< vector to save the lonely points in global map coordinates
+  std::vector<std::vector<geometry_msgs::Point>> _prohibition_polygons;         //!< vector to save the polygons (including lines) in source coordinates
+  std::vector<std::vector<geometry_msgs::Point>> _prohibition_polygons_global;  //!< vector to save the polygons (including lines) in global coordinates
+  double _min_x, _min_y, _max_x, _max_y;                                        //!< cached map bounds
 };
 }
 #endif

--- a/src/costmap_prohibition_layer.cpp
+++ b/src/costmap_prohibition_layer.cpp
@@ -46,8 +46,14 @@ using costmap_2d::LETHAL_OBSTACLE;
 namespace costmap_prohibition_layer_namespace
 {
     
-CostmapProhibitionLayer::CostmapProhibitionLayer()
+CostmapProhibitionLayer::CostmapProhibitionLayer() : _dsrv(NULL)
 {
+}
+
+CostmapProhibitionLayer::~CostmapProhibitionLayer()
+{
+    if (_dsrv!=NULL)
+        delete _dsrv;
 }
 
 void CostmapProhibitionLayer::onInitialize()
@@ -55,10 +61,10 @@ void CostmapProhibitionLayer::onInitialize()
   ros::NodeHandle nh("~/" + name_);
   current_ = true;
 
-  dsrv_ = new dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>(nh);
-  dynamic_reconfigure::Server<costmap_2d::GenericPluginConfig>::CallbackType cb =
+  _dsrv = new dynamic_reconfigure::Server<CostmapProhibitionLayerConfig>(nh);
+  dynamic_reconfigure::Server<CostmapProhibitionLayerConfig>::CallbackType cb =
       boost::bind(&CostmapProhibitionLayer::reconfigureCB, this, _1, _2);
-  dsrv_->setCallback(cb);
+  _dsrv->setCallback(cb);
 
   // get a pointer to the layered costmap and save resolution
   costmap_2d::Costmap2D *costmap = layered_costmap_->getCostmap();
@@ -82,9 +88,10 @@ void CostmapProhibitionLayer::onInitialize()
   ROS_INFO("CostmapProhibitionLayer initialized.");
 }
 
-void CostmapProhibitionLayer::reconfigureCB(costmap_2d::GenericPluginConfig &config, uint32_t level)
+void CostmapProhibitionLayer::reconfigureCB(CostmapProhibitionLayerConfig &config, uint32_t level)
 {
   enabled_ = config.enabled;
+  _fill_polygons = config.fill_polygons;
 }
 
 

--- a/src/costmap_prohibition_layer.cpp
+++ b/src/costmap_prohibition_layer.cpp
@@ -215,50 +215,23 @@ void CostmapProhibitionLayer::setPolygonCost(costmap_2d::Costmap2D &master_grid,
                                              int min_i, int min_j, int max_i, int max_j)
 {
    std::vector<PointInt> map_polygon;
-   int xoffset = 0;
-   int yoffset = 0;
    for (unsigned int i = 0; i < polygon.size(); ++i)
    {
      PointInt loc;
      master_grid.worldToMapNoBounds(polygon[i].x, polygon[i].y, loc.x, loc.y);
-//      int di = loc.x-min_i;
-//      if (di < xoffset)
-//          xoffset = di;
-//      int dj = loc.y-min_j;
-//      if (dj < yoffset)
-//          yoffset = dj;
      map_polygon.push_back(loc);
    }
-//    xoffset = std::abs(xoffset);
-//    yoffset = std::abs(yoffset);
-//    ROS_INFO_STREAM("xoffset: " << xoffset << ", y: " << yoffset);
-    // transform points to allow its representation as unsigned int (the costmap_2d algorithms accept only unsigned int values)
-    std::vector<PointInt> map_polygon_shifted(map_polygon.size());
-    for (unsigned int i = 0; i < map_polygon.size(); ++i)
-    {
-        map_polygon_shifted[i].x = map_polygon[i].x + xoffset;
-        map_polygon_shifted[i].y = map_polygon[i].y + yoffset;
-    }
-   
-   
-//    if (points_inside == 0)
-//    {
-//        // all points are outside bounds, do not set any cost
-//        // we assume that our region is not contained in the interior of any "huge" polygon
-//        return;
-//    }
-
+  
     std::vector<PointInt> polygon_cells;
     
     // get the cells that fill the polygon
-//     master_grid.convexFillCells(map_polygon_shifted, polygon_cells);
-  polygonOutlineCells(map_polygon_shifted, polygon_cells);
+    polygonOutlineCells(map_polygon, polygon_cells);
     
    // set the cost of those cells
    for (unsigned int i = 0; i < polygon_cells.size(); ++i)
    {
-       int mx = polygon_cells[i].x - xoffset;
-       int my = polygon_cells[i].y - yoffset;
+       int mx = polygon_cells[i].x;
+       int my = polygon_cells[i].y;
        // check if point is outside bounds
        if (mx < min_i || mx >= max_i)
            continue;

--- a/src/costmap_prohibition_layer.cpp
+++ b/src/costmap_prohibition_layer.cpp
@@ -45,6 +45,7 @@ using costmap_2d::LETHAL_OBSTACLE;
 
 namespace costmap_prohibition_layer_namespace
 {
+    
 CostmapProhibitionLayer::CostmapProhibitionLayer()
 {
 }
@@ -66,14 +67,14 @@ void CostmapProhibitionLayer::onInitialize()
   // set initial bounds
   _min_x = _min_y = _max_x = _max_y = 0;
   
-  _source_frame = "map";
-  nh.param("source_frame", _source_frame, _source_frame);
-
   // reading the prohibition areas out of the namespace of this plugin!
   // e.g.: "move_base/global_costmap/prohibition_layer/prohibition_areas"
   std::string params = "prohibition_areas";
   if (!parseProhibitionListFromYaml(&nh, params))
     ROS_ERROR_STREAM("Reading prohibition areas from '" << nh.getNamespace() << "/" << params << "' failed!");
+  
+  _fill_polygons = true;
+  nh.param("fill_polygons", _fill_polygons, _fill_polygons);
   
   // compute map bounds for the current set of prohibition areas.
   computeMapBounds();
@@ -96,12 +97,6 @@ void CostmapProhibitionLayer::updateBounds(double robot_x, double robot_y, doubl
     if (_prohibition_points.empty() && _prohibition_polygons.empty())
         return;
 
-    transformProhibitionAreas();
-    computeMapBounds();
-    
-//     ROS_INFO_STREAM("robotx: " << robot_x << " y: " << robot_y << " yaw: " << robot_yaw);
-//     ROS_INFO_STREAM("origin_x: " << layered_costmap_->getCostmap()->getOriginX() << " origin_y: " << layered_costmap_->getCostmap()->getOriginY());
-//     ROS_INFO_STREAM("min_x: " << *min_x << "/" << _min_x << ", " << "min_y: " << *min_y << "/" << _min_y << ", " << "max_x: " << *max_x << "/" << _max_x << ", " << "max_y: " << *max_y << "/" << _max_y);
     *min_x = std::min(*min_x, _min_x);
     *min_y = std::min(*min_y, _min_y);
     *max_x = std::max(*max_x, _max_x);
@@ -115,23 +110,20 @@ void CostmapProhibitionLayer::updateCosts(costmap_2d::Costmap2D &master_grid, in
     return;
 
   // set costs of polygons
-  for (int i = 0; i < _prohibition_polygons_global.size(); ++i)
+  for (int i = 0; i < _prohibition_polygons.size(); ++i)
   {
-      setPolygonCost(master_grid, _prohibition_polygons_global[i], LETHAL_OBSTACLE, min_i, min_j, max_i, max_j);
+      setPolygonCost(master_grid, _prohibition_polygons[i], LETHAL_OBSTACLE, min_i, min_j, max_i, max_j, _fill_polygons);
   }
       
-//       ROS_INFO_STREAM("mini: " << min_i << " minj: " << min_j << " maxi: " << max_i << " maxj: " << max_j);
   // set cost of points
-  for (int i = 0; i < _prohibition_points_global.size(); ++i)
+  for (int i = 0; i < _prohibition_points.size(); ++i)
   {
     unsigned int mx;
     unsigned int my;
-    if (master_grid.worldToMap(_prohibition_points_global[i].x, _prohibition_points_global[i].y, mx, my))
+    if (master_grid.worldToMap(_prohibition_points[i].x, _prohibition_points[i].y, mx, my))
     {
       master_grid.setCost(mx, my, LETHAL_OBSTACLE);
     }
-//     else
-//       ROS_ERROR_STREAM("Prohibition Layer: Point Cost couldn't be set!");
   }
 }
 
@@ -141,12 +133,12 @@ void CostmapProhibitionLayer::computeMapBounds()
   _min_x = _min_y = _max_x = _max_y = 0;
     
   // iterate polygons
-  for (int i = 0; i < _prohibition_polygons_global.size(); ++i)
+  for (int i = 0; i < _prohibition_polygons.size(); ++i)
   {
-    for (int j=0; j < _prohibition_polygons_global.at(i).size(); ++j)
+    for (int j=0; j < _prohibition_polygons.at(i).size(); ++j)
     {
-      double px = _prohibition_polygons_global.at(i).at(j).x;
-      double py = _prohibition_polygons_global.at(i).at(j).y;
+      double px = _prohibition_polygons.at(i).at(j).x;
+      double py = _prohibition_polygons.at(i).at(j).y;
       _min_x = std::min(px, _min_x);
       _min_y = std::min(py, _min_y);
       _max_x = std::max(px, _max_x);
@@ -155,10 +147,10 @@ void CostmapProhibitionLayer::computeMapBounds()
   }
 
   // iterate points
-  for (int i = 0; i < _prohibition_points_global.size(); ++i)
+  for (int i = 0; i < _prohibition_points.size(); ++i)
   {
-      double px = _prohibition_points_global.at(i).x;
-      double py = _prohibition_points_global.at(i).y;
+      double px = _prohibition_points.at(i).x;
+      double py = _prohibition_points.at(i).y;
       _min_x = std::min(px, _min_x);
       _min_y = std::min(py, _min_y);
       _max_x = std::max(px, _max_x);
@@ -166,81 +158,159 @@ void CostmapProhibitionLayer::computeMapBounds()
   }
 }
 
-bool CostmapProhibitionLayer::transformProhibitionAreas()
-{
-    tf::StampedTransform tf_source_to_global;
-    try
-    {
-        tf_->waitForTransform(layered_costmap_->getGlobalFrameID(), _source_frame, ros::Time::now(), ros::Duration(3));
-        tf_->lookupTransform(layered_costmap_->getGlobalFrameID(), _source_frame, ros::Time(0), tf_source_to_global);
-    }
-    catch(const tf::TransformException& ex)
-    {
-        ROS_ERROR_STREAM("CostmapProhibitionLayer: " << ex.what());
-        return false;
-    }
-    
-    // TODO: only renew if transformation has changed!   
-    
-    // iterate polygons
-    _prohibition_polygons_global.resize(_prohibition_polygons.size());
-    for (int i = 0; i < _prohibition_polygons.size(); ++i)
-    {
-        _prohibition_polygons_global[i].resize(_prohibition_polygons.at(i).size());
-        for (int j=0; j < _prohibition_polygons.at(i).size(); ++j)
-        {
-            transformPoint(tf_source_to_global, _prohibition_polygons.at(i).at(j), _prohibition_polygons_global.at(i).at(j));
-        }
-    }
-
-    // iterate points
-    _prohibition_points_global.resize(_prohibition_points.size());
-    for (int i = 0; i < _prohibition_points.size(); ++i)
-    {
-        transformPoint(tf_source_to_global, _prohibition_points[i], _prohibition_points_global[i]);
-    }    
-    return true;
-}
-
-
-void CostmapProhibitionLayer::transformPoint(const tf::StampedTransform& transform, const geometry_msgs::Point& pt_in, geometry_msgs::Point& pt_out)
-{
-    tf::Stamped<tf::Point> pin, pout;
-    tf::pointMsgToTF(pt_in, pin);
-    pout.setData(transform * pin);
-    tf::pointTFToMsg(pout, pt_out);     
-}
 
 void CostmapProhibitionLayer::setPolygonCost(costmap_2d::Costmap2D &master_grid, const std::vector<geometry_msgs::Point>& polygon, unsigned char cost,
-                                             int min_i, int min_j, int max_i, int max_j)
+                                             int min_i, int min_j, int max_i, int max_j, bool fill_polygon)
 {
-   std::vector<PointInt> map_polygon;
-   for (unsigned int i = 0; i < polygon.size(); ++i)
-   {
-     PointInt loc;
-     master_grid.worldToMapNoBounds(polygon[i].x, polygon[i].y, loc.x, loc.y);
-     map_polygon.push_back(loc);
-   }
-  
+    std::vector<PointInt> map_polygon;
+    for (unsigned int i = 0; i < polygon.size(); ++i)
+    {
+        PointInt loc;
+        master_grid.worldToMapNoBounds(polygon[i].x, polygon[i].y, loc.x, loc.y);
+        map_polygon.push_back(loc);
+    }
+
     std::vector<PointInt> polygon_cells;
-    
+
     // get the cells that fill the polygon
-    polygonOutlineCells(map_polygon, polygon_cells);
-    
-   // set the cost of those cells
-   for (unsigned int i = 0; i < polygon_cells.size(); ++i)
-   {
-       int mx = polygon_cells[i].x;
-       int my = polygon_cells[i].y;
-       // check if point is outside bounds
-       if (mx < min_i || mx >= max_i)
-           continue;
-       if (my < min_j || my >= max_j)
-           continue;
-       master_grid.setCost(mx, my, cost);
-   }
+    rasterizePolygon(map_polygon, polygon_cells, fill_polygon);
+
+    // set the cost of those cells
+    for (unsigned int i = 0; i < polygon_cells.size(); ++i)
+    {
+        int mx = polygon_cells[i].x;
+        int my = polygon_cells[i].y;
+        // check if point is outside bounds
+        if (mx < min_i || mx >= max_i)
+            continue;
+        if (my < min_j || my >= max_j)
+            continue;
+        master_grid.setCost(mx, my, cost);
+    }
 }
 
+
+void CostmapProhibitionLayer::polygonOutlineCells(const std::vector<PointInt>& polygon, std::vector<PointInt>& polygon_cells)
+  {
+     for (unsigned int i = 0; i < polygon.size() - 1; ++i)
+     {
+       raytrace(polygon[i].x, polygon[i].y, polygon[i + 1].x, polygon[i + 1].y, polygon_cells);
+     }
+     if (!polygon.empty())
+     {
+       unsigned int last_index = polygon.size() - 1;
+       // we also need to close the polygon by going from the last point to the first
+       raytrace(polygon[last_index].x, polygon[last_index].y, polygon[0].x, polygon[0].y, polygon_cells);
+     }
+  }
+
+void CostmapProhibitionLayer::raytrace(int x0, int y0, int x1, int y1, std::vector<PointInt>& cells)
+{
+    int dx = abs(x1 - x0);
+    int dy = abs(y1 - y0);
+    PointInt pt;
+    pt.x = x0;
+    pt.y = y0;
+    int n = 1 + dx + dy;
+    int x_inc = (x1 > x0) ? 1 : -1;
+    int y_inc = (y1 > y0) ? 1 : -1;
+    int error = dx - dy;
+    dx *= 2;
+    dy *= 2;
+        
+    for (; n > 0; --n)
+    {
+        cells.push_back(pt);
+
+        if (error > 0)
+        {
+            pt.x += x_inc;
+            error -= dy;
+        }
+        else
+        {
+            pt.y += y_inc;
+            error += dx;
+        }
+    }
+}
+
+
+void CostmapProhibitionLayer::rasterizePolygon(const std::vector<PointInt>& polygon, std::vector<PointInt>& polygon_cells, bool fill)
+{
+    // this implementation is a slighly modified version of Costmap2D::convexFillCells(...)
+
+    //we need a minimum polygon of a traingle
+    if(polygon.size() < 3)
+        return;
+
+    //first get the cells that make up the outline of the polygon
+    polygonOutlineCells(polygon, polygon_cells);
+
+    if (!fill)
+        return;
+
+    //quick bubble sort to sort points by x
+    PointInt swap;
+    unsigned int i = 0;
+    while(i < polygon_cells.size() - 1)
+    {
+        if(polygon_cells[i].x > polygon_cells[i + 1].x)
+        {
+            swap = polygon_cells[i];
+            polygon_cells[i] = polygon_cells[i + 1];
+            polygon_cells[i + 1] = swap;
+
+            if(i > 0)
+            --i;
+        }
+        else
+            ++i;
+        }
+
+        i = 0;
+        PointInt min_pt;
+        PointInt max_pt;
+        int min_x = polygon_cells[0].x;
+        int max_x = polygon_cells[(int)polygon_cells.size() -1].x;
+
+        //walk through each column and mark cells inside the polygon
+        for(int x = min_x; x <= max_x; ++x)
+        {
+            if(i >= (int)polygon_cells.size() - 1)
+                break;
+
+            if(polygon_cells[i].y < polygon_cells[i + 1].y)
+            {
+                min_pt = polygon_cells[i];
+                max_pt = polygon_cells[i + 1];
+            }
+            else
+            {
+                min_pt = polygon_cells[i + 1];
+                max_pt = polygon_cells[i];
+            }
+
+            i += 2;
+            while(i < polygon_cells.size() && polygon_cells[i].x == x)
+            {
+                if(polygon_cells[i].y < min_pt.y)
+                    min_pt = polygon_cells[i];
+                else if(polygon_cells[i].y > max_pt.y)
+                    max_pt = polygon_cells[i];
+                ++i;
+            }
+
+            PointInt pt;
+            //loop though cells in the column
+            for(int y = min_pt.y; y < max_pt.y; ++y)
+            {
+                pt.x = x;
+                pt.y = y;
+                polygon_cells.push_back(pt);
+            }
+        }
+  }
 
 // load prohibition positions out of the rosparam server
 bool CostmapProhibitionLayer::parseProhibitionListFromYaml(ros::NodeHandle *nhandle, const std::string &param)

--- a/src/costmap_prohibition_layer.cpp
+++ b/src/costmap_prohibition_layer.cpp
@@ -101,6 +101,8 @@ void CostmapProhibitionLayer::updateBounds(double robot_x, double robot_y, doubl
     if (!enabled_)
         return;
     
+    std::lock_guard<std::mutex> l(_data_mutex);
+    
     if (_prohibition_points.empty() && _prohibition_polygons.empty())
         return;
 
@@ -116,6 +118,8 @@ void CostmapProhibitionLayer::updateCosts(costmap_2d::Costmap2D &master_grid, in
   if (!enabled_)
     return;
 
+  std::lock_guard<std::mutex> l(_data_mutex);
+  
   // set costs of polygons
   for (int i = 0; i < _prohibition_polygons.size(); ++i)
   {
@@ -136,6 +140,8 @@ void CostmapProhibitionLayer::updateCosts(costmap_2d::Costmap2D &master_grid, in
 
 void CostmapProhibitionLayer::computeMapBounds()
 {
+  std::lock_guard<std::mutex> l(_data_mutex);
+    
   // reset bounds
   _min_x = _min_y = _max_x = _max_y = 0;
     
@@ -322,7 +328,7 @@ void CostmapProhibitionLayer::rasterizePolygon(const std::vector<PointInt>& poly
 // load prohibition positions out of the rosparam server
 bool CostmapProhibitionLayer::parseProhibitionListFromYaml(ros::NodeHandle *nhandle, const std::string &param)
 {
-  std::lock_guard<std::mutex> l(_parse_mutex);
+  std::lock_guard<std::mutex> l(_data_mutex);
   std::unordered_map<std::string, geometry_msgs::Pose> map_out;
 
   XmlRpc::XmlRpcValue param_yaml;


### PR DESCRIPTION
This patch adds the support for rolling windows.
Furthermore, with this patch the user can decide whether to only mark complete polygons
or only its boundaries as obstacle (-> dynamic reconfigure option).

Prerequisits:
The global frame of the rolling window (_local costmap_) must be the same as for the global map, e.g. `/map`. Do not use the `odom` frame here in case you have a `/map` transformation from amcl or something similar.